### PR TITLE
Add remember password option

### DIFF
--- a/snippets/password-protection.liquid
+++ b/snippets/password-protection.liquid
@@ -22,7 +22,7 @@
 {% comment %}
   CONFIGURATION OPTIONS - Edit these values to change behavior
 {% endcomment %}
-{% assign always_require_password = true %}
+{% assign always_require_password = false %}
 {% comment %}
   Set to true to always require password entry on every page refresh
   Set to false to remember passwords using localStorage
@@ -103,8 +103,19 @@
       justify-content: center;
       margin-top: 10px;
     }
-    
+
     #show-password {
+      margin-right: 5px;
+    }
+
+    #save-password-container {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-top: 10px;
+    }
+
+    #save-password {
       margin-right: 5px;
     }
   </style>
@@ -114,8 +125,12 @@
       <h4>Enter Password to Access</h4> 
       <input type="password" id="password-input" placeholder="Enter password" />
       <div id="show-password-container">
-        <input type="checkbox" id="show-password"> 
+        <input type="checkbox" id="show-password">
         <label for="show-password">Show Password</label>
+      </div>
+      <div id="save-password-container">
+        <input type="checkbox" id="save-password">
+        <label for="save-password">Remember Password</label>
       </div>
       <button onclick="checkPassword()">Submit</button>
       <p id="error-message" style="color: red; display: none;">Incorrect password. Please try again.</p>
@@ -168,8 +183,9 @@
       if (alwaysRequirePassword) {
         return; // Always show password prompt
       }
-      
+
       if (storedPassword === '{{ page_password }}') {
+        document.getElementById('save-password').checked = true;
         unlockContent();
       }
     }
@@ -183,20 +199,25 @@
       }, 300);
     }
 
-    function checkPassword() {
-      const input = document.getElementById('password-input').value;
-      const errorMessage = document.getElementById('error-message');
-      const pageId = '{{ page.id }}';
-      
+   function checkPassword() {
+     const input = document.getElementById('password-input').value;
+     const errorMessage = document.getElementById('error-message');
+     const pageId = '{{ page.id }}';
+     const rememberPassword = document.getElementById('save-password').checked;
+
       if (input === '{{ page_password }}') {
-        // Store in localStorage for persistence
         const rememberedPasswords = JSON.parse(localStorage.getItem('pagePasswords') || '{}');
-        rememberedPasswords[pageId] = input;
+        if (rememberPassword) {
+          // Store in localStorage for persistence
+          rememberedPasswords[pageId] = input;
+        } else {
+          delete rememberedPasswords[pageId];
+        }
         localStorage.setItem('pagePasswords', JSON.stringify(rememberedPasswords));
-        
+
         // Unlock the content
         unlockContent();
-        
+
         errorMessage.style.display = 'none';
       } else {
         errorMessage.style.display = 'block';


### PR DESCRIPTION
## Summary
- enhance password-protection snippet with "Remember Password" option
- allow password to persist by default

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840323f049c83229b3a1a99f163cd64